### PR TITLE
一部のテストを通せませんでした

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ただし、中身が実装されていません。
 実装して、ユニットテストが通るようにしてください。
 
-[![MS Build and Test](https://github.com/tpu-game-2021/comp2_8_stack/actions/workflows/ms_test.yml/badge.svg)](https://github.com/tpu-game-2021/comp2_8_stack/actions/workflows/ms_test.yml)
+[![MS Build and Test](https://github.com/Harmony82/comp2_8_stack/actions/workflows/ms_test.yml/badge.svg)](https://github.com/Harmony82/comp2_8_stack/actions/workflows/ms_test.yml)
 
 （このファイルの上の行の[tpu-game-2021]の部分(2か所)を自分のアカウント名に修正してください）
 

--- a/src/StaticLib/StaticLib.c
+++ b/src/StaticLib/StaticLib.c
@@ -10,47 +10,80 @@ void initialize(STACK* s, size_t mem_size)
 {
 	if (s == NULL) return;
 
-	s->stack_pointer = NULL;
-	s->stack_memory = NULL;
-	s->end = NULL;
+	s->stack_memory = (int*)malloc(mem_size);
+	if (s->stack_memory == NULL) exit(0);
+	s->stack_pointer = 0;
+	s->end = mem_size;
 }
 
 
 // 確保したメモリを解放する
 void finalize(STACK* s)
 {
-	// ToDo: Initializeで確保したメモリを解放しよう
+	if (s == NULL) return;
+	free(s->stack_memory);
+	s->stack_memory = NULL;
+	s->end = NULL;
 }
 
 
 // valの値をスタックに積む。実行の成否を返す
 bool push(STACK* s, int val)
 {
+	if (s == NULL) return false;
 	// ToDo: valの値をスタックに保存しよう
-	return false;
+	if (s->stack_pointer >= s->end){
+		return false;
+	}
+	s->stack_memory[s->stack_pointer] = val;
+	s->stack_pointer+=sizeof(int);
+
+	return true;
 }
 
 
 // addrから始まるnum個の整数をスタックに積む。実行の成否を返す
 bool push_array(STACK* s, int* addr, int num)
 {
-	// ToDo: addrからはじまるnum個の整数をスタックに保存しよう
-	return false;
+	if (s == NULL) return false;
+	if (s->stack_pointer + (sizeof(int) * num) > s->end){
+		return false;
+	}
+
+	for (int i = 0; i < num; i++)
+	{
+		s->stack_memory[s->stack_pointer] = addr[num-1-i];
+		s->stack_pointer += sizeof(int);
+	}
+	return true;
 }
 
 // スタックから一つの要素を取り出す
 int pop(STACK* s)
 {
-	// ToDo: スタックの最上位の値を取り出して返そう
-	// 不具合時は0を返す
-	return 0;
+	if (s == NULL) return 0;
+	if (s->stack_pointer <= 0) {
+		return 0;
+	}
+	
+	s->stack_pointer -=sizeof(int);
+	return s->stack_memory[s->stack_pointer];
 }
 
 // addrにスタックからnumの要素を取り出す。取り出せた個数を返す
 int pop_array(STACK* s, int* addr, int num)
 {
-	// ToDo: スタックからnum個の値を取り出してaddrから始まるメモリに保存しよう
-	// スタックにnum個の要素がたまっていなかたら、積まれている要素を返して、
-	// 積んだ要素数を返り値として返そう
-	return 0;
+	if (s == NULL) return 0;
+	int i, count=0;
+	for ( i=0; i < num; i++)
+	{
+		s->stack_pointer -= sizeof(int);
+		if (s->stack_pointer < 0)
+		{
+			break;
+		}
+		addr[i] = s->stack_memory[s->stack_pointer];
+		count++;
+	}
+	return count;
 }

--- a/src/include/lib_func.h
+++ b/src/include/lib_func.h
@@ -9,9 +9,9 @@ extern "C" {
 
 typedef struct
 {
-	int* stack_pointer;
+	int  stack_pointer;
 	int* stack_memory;
-	int* end;          // スタックが底をついたか確認するためのポインタ（構造体を変更して別実装にしても良い）
+	int end;          // スタックが底をついたか確認するためのポインタ（構造体を変更して別実装にしても良い）
 }STACK;
 
 void initialize(STACK* s, size_t mem_size);   // mem_size の容量でスタック用のメモリを確保する


### PR DESCRIPTION
構造体を変更しスタックポインタを通常のint型として「s->stack_memory[s->stack_pointer]」で実装しました。
1000万個積むテストが通りませんでした。試しに10個でやったら通ったので原因がわかりませんでした。エラーを見る限り範囲外にアクセスしているようですがなぜでしょうか。
コンソールアプリケーションは正常に動作しました。